### PR TITLE
fix(ci): specify pnpm package.json path for monorepo setup

### DIFF
--- a/.github/workflows/auto-i18n.yml
+++ b/.github/workflows/auto-i18n.yml
@@ -24,6 +24,9 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
+        with:
+          package_json_file: web/package.json
+          run_install: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary

Fix pnpm setup in GitHub Actions workflow by specifying the correct package.json path for monorepo structure.

The previous configuration was failing with "No pnpm version is specified" because pnpm/action-setup@v4 could not find the package.json file in the monorepo structure.

## Type

- [x] 🐛 Bug fix  
- [ ] ✨ Feature  
- [ ] 💥 Breaking change  
- [ ] 📚 Docs  
- [ ] ♻️ Refactor  
- [ ] ⚡ Performance  

## Changes

- Add `package_json_file: web/package.json` to pnpm setup action
- Add `run_install: false` to prevent automatic installation at setup step
- Ensure proper pnpm version detection from `packageManager` field in web/package.json

## Testing

This will be tested when the i18n automation workflow runs after merging the main PR.